### PR TITLE
Bump to ordered-float 0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ license = "MIT"
 
 [dependencies]
 serde = "^0.7.0"
-ordered-float = "^0.0.2"
+ordered-float = "^0.1.0"


### PR DESCRIPTION
This in particular drops the transitive dependency on rustc_serialize.