### PR TITLE
Upgrade to serde 0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,5 @@ keywords = ["serde"]
 license = "MIT"
 
 [dependencies]
-serde = "^0.7.0"
-ordered-float = "^0.1.0"
+serde = "*"
+ordered-float = "*"


### PR DESCRIPTION
I also removed version constraints because according to `semver`, `0.y.z` versions don't offer any API compatibility guarantees whatsoever.