### PR TITLE
update ordered-float

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT"
 
 [dependencies]
 serde = "^1.0.0"
-ordered-float = "^0.5.0"
+ordered-float = "^1.0.1"
 
 [dev-dependencies]
 serde_derive = "^1.0.0"


### PR DESCRIPTION
I'm chasing down outdated in dependencies in some code I work on, and find that I am getting an old `ordered-float` via `serde-value` (via `log4rs`).  This pull request brings it up to date.

All of this project's dependencies are then 1.x, which is nice, and I see that there's not a lot of change going on here.  Maybe time to consider going 1.0 yourself...?