### PR TITLE
Provide `ValueDeserializer` that impls `serde::Deserializer` with generic error type

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -307,7 +307,7 @@ impl<'de> de::IntoDeserializer<'de, DeserializerError> for Value {
 
 pub struct ValueDeserializer<E> {
     value: Value,
-    error: PhantomData<E>,
+    error: PhantomData<fn() -> E>,
 }
 
 impl<E> ValueDeserializer<E> {
@@ -446,7 +446,7 @@ impl<'de> de::Deserializer<'de> for Value {
 struct EnumDeserializer<E> {
     variant: Value,
     value: Option<Value>,
-    error: PhantomData<E>,
+    error: PhantomData<fn() -> E>,
 }
 
 impl<'de, E> de::EnumAccess<'de> for EnumDeserializer<E> where E: de::Error {
@@ -466,7 +466,7 @@ impl<'de, E> de::EnumAccess<'de> for EnumDeserializer<E> where E: de::Error {
 
 struct VariantDeserializer<E> {
     value: Option<Value>,
-    error: PhantomData<E>,
+    error: PhantomData<fn() -> E>,
 }
 
 impl<'de, E> de::VariantAccess<'de> for VariantDeserializer<E> where E: de::Error {


### PR DESCRIPTION
Other changes:

- Fix `deserialize_option` to call `visit_unit` rather than `visit_none`,
  just like serde's `ContentDeserializer` does.

- Remove `MapVisitor` since `serde::de::value::MapDeserializer` can be used
  directly.

Fixes #23