### PR TITLE
Fix newtype deserializer to fall back to other types if value is not explicitly a Newtype

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -402,9 +402,19 @@ impl<'de, E> de::Deserializer<'de> for ValueDeserializer<E> where E: de::Error {
         visitor.visit_enum(d)
     }
 
+    fn deserialize_newtype_struct<V: de::Visitor<'de>>(self,
+                                                       _name: &'static str,
+                                                       visitor: V)
+                                                       -> Result<V::Value, Self::Error> {
+        match self.value {
+            Value::Newtype(v) => visitor.visit_newtype_struct(ValueDeserializer::new(*v)),
+            _ => visitor.visit_newtype_struct(self),
+        }
+    }
+
     forward_to_deserialize_any! {
         bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string unit
-        seq bytes byte_buf map unit_struct newtype_struct
+        seq bytes byte_buf map unit_struct
         tuple_struct struct tuple ignored_any identifier
     }
 }
@@ -436,9 +446,16 @@ impl<'de> de::Deserializer<'de> for Value {
         ValueDeserializer::new(self).deserialize_enum(name, variants, visitor)
     }
 
+    fn deserialize_newtype_struct<V: de::Visitor<'de>>(self,
+                                                       name: &'static str,
+                                                       visitor: V)
+                                                       -> Result<V::Value, Self::Error> {
+        ValueDeserializer::new(self).deserialize_newtype_struct(name, visitor)
+    }
+
     forward_to_deserialize_any! {
         bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string unit
-        seq bytes byte_buf map unit_struct newtype_struct
+        seq bytes byte_buf map unit_struct
         tuple_struct struct tuple ignored_any identifier
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,3 +306,30 @@ fn deserialize_inside_deserialize_impl() {
     ].into_iter().collect());
     let _ = Event::deserialize(input).expect_err("expected deserializing bad ADDED event to fail");
 }
+
+#[test]
+fn deserialize_newtype() {
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Foo(i32);
+
+    let input = Value::I32(5);
+    let foo = Foo::deserialize(input).unwrap();
+    assert_eq!(foo, Foo(5));
+}
+
+#[test]
+fn deserialize_newtype2() {
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Foo(i32);
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Bar {
+        foo: Foo,
+    }
+
+    let input = Value::Map(vec![
+        (Value::String("foo".to_owned()), Value::I32(5))
+    ].into_iter().collect());
+    let bar = Bar::deserialize(input).unwrap();
+    assert_eq!(bar, Bar { foo: Foo(5) });
+}


### PR DESCRIPTION
Fixes #22

---

This matches what `serde::private::de::ContentDeserializer::visit_newtype_struct` does.

The first commit is from #24 since that PR moves the `Deserializer` impl code away from `Value`.