### PR TITLE
Fix enum serialization

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -76,7 +76,6 @@ impl Unexpected {
             Unexpected::Other(ref v) => de::Unexpected::Other(v),
         }
     }
-
 }
 
 #[derive(Debug)]
@@ -158,21 +157,33 @@ impl fmt::Display for DeserializerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             DeserializerError::Custom(ref msg) => write!(f, "{}", msg),
-            DeserializerError::InvalidType(ref unexp, ref exp) => {
-                write!(f, "Invalid type {}. Expected {}", unexp.to_unexpected(), exp)
-            }
-            DeserializerError::InvalidValue(ref unexp, ref exp) => {
-                write!(f, "Invalid value {}. Expected {}", unexp.to_unexpected(), exp)
-            }
+            DeserializerError::InvalidType(ref unexp, ref exp) => write!(
+                f,
+                "Invalid type {}. Expected {}",
+                unexp.to_unexpected(),
+                exp
+            ),
+            DeserializerError::InvalidValue(ref unexp, ref exp) => write!(
+                f,
+                "Invalid value {}. Expected {}",
+                unexp.to_unexpected(),
+                exp
+            ),
             DeserializerError::InvalidLength(len, ref exp) => {
                 write!(f, "Invalid length {}. Expected {}", len, exp)
             }
-            DeserializerError::UnknownVariant(ref field, exp) => {
-                write!(f, "Unknown variant {}. Expected one of {}", field, exp.join(", "))
-            },
-            DeserializerError::UnknownField(ref field, exp) => {
-                write!(f, "Unknown field {}. Expected one of {}", field, exp.join(", "))
-            }
+            DeserializerError::UnknownVariant(ref field, exp) => write!(
+                f,
+                "Unknown variant {}. Expected one of {}",
+                field,
+                exp.join(", ")
+            ),
+            DeserializerError::UnknownField(ref field, exp) => write!(
+                f,
+                "Unknown field {}. Expected one of {}",
+                field,
+                exp.join(", ")
+            ),
             DeserializerError::MissingField(field) => write!(f, "Missing field {}", field),
             DeserializerError::DuplicateField(field) => write!(f, "Duplicate field {}", field),
         }
@@ -259,11 +270,13 @@ impl<'de> de::Visitor<'de> for ValueVisitor {
     }
 
     fn visit_some<D: de::Deserializer<'de>>(self, d: D) -> Result<Value, D::Error> {
-        d.deserialize_any(ValueVisitor).map(|v| Value::Option(Some(Box::new(v))))
+        d.deserialize_any(ValueVisitor)
+            .map(|v| Value::Option(Some(Box::new(v))))
     }
 
     fn visit_newtype_struct<D: de::Deserializer<'de>>(self, d: D) -> Result<Value, D::Error> {
-        d.deserialize_any(ValueVisitor).map(|v| Value::Newtype(Box::new(v)))
+        d.deserialize_any(ValueVisitor)
+            .map(|v| Value::Newtype(Box::new(v)))
     }
 
     fn visit_seq<V: de::SeqAccess<'de>>(self, mut visitor: V) -> Result<Value, V::Error> {
@@ -323,7 +336,10 @@ impl<E> ValueDeserializer<E> {
     }
 }
 
-impl<'de, E> de::Deserializer<'de> for ValueDeserializer<E> where E: de::Error {
+impl<'de, E> de::Deserializer<'de> for ValueDeserializer<E>
+where
+    E: de::Error,
+{
     type Error = E;
 
     fn deserialize_any<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
@@ -345,15 +361,13 @@ impl<'de, E> de::Deserializer<'de> for ValueDeserializer<E> where E: de::Error {
             Value::Option(None) => visitor.visit_none(),
             Value::Option(Some(v)) => visitor.visit_some(ValueDeserializer::new(*v)),
             Value::Newtype(v) => visitor.visit_newtype_struct(ValueDeserializer::new(*v)),
-            Value::Seq(v) => {
-                visitor.visit_seq(de::value::SeqDeserializer::new(v.into_iter().map(ValueDeserializer::new)))
-            },
-            Value::Map(v) => {
-                visitor.visit_map(de::value::MapDeserializer::new(v.into_iter().map(|(k, v)| (
-                    ValueDeserializer::new(k),
-                    ValueDeserializer::new(v),
-                ))))
-            },
+            Value::Seq(v) => visitor.visit_seq(de::value::SeqDeserializer::new(
+                v.into_iter().map(ValueDeserializer::new),
+            )),
+            Value::Map(v) => visitor
+                .visit_map(de::value::MapDeserializer::new(v.into_iter().map(
+                    |(k, v)| (ValueDeserializer::new(k), ValueDeserializer::new(v)),
+                ))),
             Value::Bytes(v) => visitor.visit_byte_buf(v),
         }
     }
@@ -362,35 +376,43 @@ impl<'de, E> de::Deserializer<'de> for ValueDeserializer<E> where E: de::Error {
         match self.value {
             Value::Option(..) => self.deserialize_any(visitor),
             Value::Unit => visitor.visit_unit(),
-            _ => visitor.visit_some(self)
+            _ => visitor.visit_some(self),
         }
     }
 
-    fn deserialize_enum<V: de::Visitor<'de>>(self,
-                                             _name: &'static str,
-                                             _variants: &'static [&'static str],
-                                             visitor: V)
-                                             -> Result<V::Value, Self::Error> {
+    fn deserialize_enum<V: de::Visitor<'de>>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
         let (variant, value) = match self.value {
             Value::Map(value) => {
                 let mut iter = value.into_iter();
                 let (variant, value) = match iter.next() {
                     Some(v) => v,
                     None => {
-                        return Err(de::Error::invalid_value(de::Unexpected::Map,
-                                                            &"map with a single key"));
+                        return Err(de::Error::invalid_value(
+                            de::Unexpected::Map,
+                            &"map with a single key",
+                        ));
                     }
                 };
                 // enums are encoded as maps with a single key:value pair
                 if iter.next().is_some() {
-                    return Err(de::Error::invalid_value(de::Unexpected::Map,
-                                                        &"map with a single key"));
+                    return Err(de::Error::invalid_value(
+                        de::Unexpected::Map,
+                        &"map with a single key",
+                    ));
                 }
                 (variant, Some(value))
             }
             Value::String(variant) => (Value::String(variant), None),
             other => {
-                return Err(de::Error::invalid_type(other.unexpected(), &"string or map"));
+                return Err(de::Error::invalid_type(
+                    other.unexpected(),
+                    &"string or map",
+                ));
             }
         };
 
@@ -402,10 +424,11 @@ impl<'de, E> de::Deserializer<'de> for ValueDeserializer<E> where E: de::Error {
         visitor.visit_enum(d)
     }
 
-    fn deserialize_newtype_struct<V: de::Visitor<'de>>(self,
-                                                       _name: &'static str,
-                                                       visitor: V)
-                                                       -> Result<V::Value, Self::Error> {
+    fn deserialize_newtype_struct<V: de::Visitor<'de>>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
         match self.value {
             Value::Newtype(v) => visitor.visit_newtype_struct(ValueDeserializer::new(*v)),
             _ => visitor.visit_newtype_struct(self),
@@ -419,7 +442,10 @@ impl<'de, E> de::Deserializer<'de> for ValueDeserializer<E> where E: de::Error {
     }
 }
 
-impl<'de, E> de::IntoDeserializer<'de, E> for ValueDeserializer<E> where E: de::Error {
+impl<'de, E> de::IntoDeserializer<'de, E> for ValueDeserializer<E>
+where
+    E: de::Error,
+{
     type Deserializer = Self;
 
     fn into_deserializer(self) -> Self::Deserializer {
@@ -438,18 +464,20 @@ impl<'de> de::Deserializer<'de> for Value {
         ValueDeserializer::new(self).deserialize_option(visitor)
     }
 
-    fn deserialize_enum<V: de::Visitor<'de>>(self,
-                                             name: &'static str,
-                                             variants: &'static [&'static str],
-                                             visitor: V)
-                                             -> Result<V::Value, Self::Error> {
+    fn deserialize_enum<V: de::Visitor<'de>>(
+        self,
+        name: &'static str,
+        variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
         ValueDeserializer::new(self).deserialize_enum(name, variants, visitor)
     }
 
-    fn deserialize_newtype_struct<V: de::Visitor<'de>>(self,
-                                                       name: &'static str,
-                                                       visitor: V)
-                                                       -> Result<V::Value, Self::Error> {
+    fn deserialize_newtype_struct<V: de::Visitor<'de>>(
+        self,
+        name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
         ValueDeserializer::new(self).deserialize_newtype_struct(name, visitor)
     }
 
@@ -466,18 +494,26 @@ struct EnumDeserializer<E> {
     error: PhantomData<fn() -> E>,
 }
 
-impl<'de, E> de::EnumAccess<'de> for EnumDeserializer<E> where E: de::Error {
+impl<'de, E> de::EnumAccess<'de> for EnumDeserializer<E>
+where
+    E: de::Error,
+{
     type Error = E;
     type Variant = VariantDeserializer<Self::Error>;
 
-    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, VariantDeserializer<Self::Error>), Self::Error>
-        where V: de::DeserializeSeed<'de>
+    fn variant_seed<V>(
+        self,
+        seed: V,
+    ) -> Result<(V::Value, VariantDeserializer<Self::Error>), Self::Error>
+    where
+        V: de::DeserializeSeed<'de>,
     {
         let visitor = VariantDeserializer {
             value: self.value,
             error: Default::default(),
         };
-        seed.deserialize(ValueDeserializer::new(self.variant)).map(|v| (v, visitor))
+        seed.deserialize(ValueDeserializer::new(self.variant))
+            .map(|v| (v, visitor))
     }
 }
 
@@ -486,7 +522,10 @@ struct VariantDeserializer<E> {
     error: PhantomData<fn() -> E>,
 }
 
-impl<'de, E> de::VariantAccess<'de> for VariantDeserializer<E> where E: de::Error {
+impl<'de, E> de::VariantAccess<'de> for VariantDeserializer<E>
+where
+    E: de::Error,
+{
     type Error = E;
 
     fn unit_variant(self) -> Result<(), Self::Error> {
@@ -497,45 +536,62 @@ impl<'de, E> de::VariantAccess<'de> for VariantDeserializer<E> where E: de::Erro
     }
 
     fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value, Self::Error>
-        where T: de::DeserializeSeed<'de>
+    where
+        T: de::DeserializeSeed<'de>,
     {
         match self.value {
             Some(value) => seed.deserialize(ValueDeserializer::new(value)),
-            None => Err(de::Error::invalid_type(de::Unexpected::UnitVariant, &"newtype variant")),
+            None => Err(de::Error::invalid_type(
+                de::Unexpected::UnitVariant,
+                &"newtype variant",
+            )),
         }
     }
 
     fn tuple_variant<V>(self, _len: usize, visitor: V) -> Result<V::Value, Self::Error>
-        where V: de::Visitor<'de>
+    where
+        V: de::Visitor<'de>,
     {
         match self.value {
-            Some(Value::Seq(v)) => {
-                de::Deserializer::deserialize_any(
-                    de::value::SeqDeserializer::new(v.into_iter().map(ValueDeserializer::new)),
-                    visitor)
-            }
-            Some(other) => Err(de::Error::invalid_type(other.unexpected(), &"tuple variant")),
-            None => Err(de::Error::invalid_type(de::Unexpected::UnitVariant, &"tuple variant")),
+            Some(Value::Seq(v)) => de::Deserializer::deserialize_any(
+                de::value::SeqDeserializer::new(v.into_iter().map(ValueDeserializer::new)),
+                visitor,
+            ),
+            Some(other) => Err(de::Error::invalid_type(
+                other.unexpected(),
+                &"tuple variant",
+            )),
+            None => Err(de::Error::invalid_type(
+                de::Unexpected::UnitVariant,
+                &"tuple variant",
+            )),
         }
     }
 
-    fn struct_variant<V>(self,
-                       _fields: &'static [&'static str],
-                       visitor: V)
-                       -> Result<V::Value, Self::Error>
-        where V: de::Visitor<'de>
+    fn struct_variant<V>(
+        self,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
     {
         match self.value {
-            Some(Value::Map(v)) => {
-                de::Deserializer::deserialize_any(
-                    de::value::MapDeserializer::new(v.into_iter().map(|(k, v)| (
-                        ValueDeserializer::new(k),
-                        ValueDeserializer::new(v),
-                    ))),
-                    visitor)
-            }
-            Some(other) => Err(de::Error::invalid_type(other.unexpected(), &"struct variant")),
-            None => Err(de::Error::invalid_type(de::Unexpected::UnitVariant, &"struct variant")),
+            Some(Value::Map(v)) => de::Deserializer::deserialize_any(
+                de::value::MapDeserializer::new(
+                    v.into_iter()
+                        .map(|(k, v)| (ValueDeserializer::new(k), ValueDeserializer::new(v))),
+                ),
+                visitor,
+            ),
+            Some(other) => Err(de::Error::invalid_type(
+                other.unexpected(),
+                &"struct variant",
+            )),
+            None => Err(de::Error::invalid_type(
+                de::Unexpected::UnitVariant,
+                &"struct variant",
+            )),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url="https://arcnmx.github.io/serde-value")]
+#![doc(html_root_url = "https://arcnmx.github.io/serde-value")]
 
 #[macro_use]
 extern crate serde;
@@ -8,11 +8,11 @@ extern crate ordered_float;
 #[macro_use]
 extern crate serde_derive;
 
-use std::collections::BTreeMap;
-use std::cmp::Ordering;
-use std::hash::{Hash, Hasher};
-use serde::Deserialize;
 use ordered_float::OrderedFloat;
+use serde::Deserialize;
+use std::cmp::Ordering;
+use std::collections::BTreeMap;
+use std::hash::{Hash, Hasher};
 
 pub use de::*;
 pub use ser::*;
@@ -51,7 +51,7 @@ pub enum Value {
 impl Hash for Value {
     fn hash<H>(&self, hasher: &mut H)
     where
-        H: Hasher
+        H: Hasher,
     {
         self.discriminant().hash(hasher);
         match *self {
@@ -186,7 +186,7 @@ impl Value {
     }
 }
 
-impl Eq for Value { }
+impl Eq for Value {}
 impl PartialOrd for Value {
     fn partial_cmp(&self, rhs: &Self) -> Option<Ordering> {
         Some(self.cmp(rhs))
@@ -201,12 +201,17 @@ fn de_smoke_test() {
         Value::Char('a'),
         Value::F32(1.0),
         Value::String("hello".into()),
-        Value::Map(vec![
-            (Value::Bool(false), Value::Unit),
-            (Value::Bool(true), Value::Newtype(Box::new(
-                Value::Bytes(b"hi".as_ref().into())
-            ))),
-        ].into_iter().collect()),
+        Value::Map(
+            vec![
+                (Value::Bool(false), Value::Unit),
+                (
+                    Value::Bool(true),
+                    Value::Newtype(Box::new(Value::Bytes(b"hi".as_ref().into()))),
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        ),
     ]))));
 
     // assert that the value remains unchanged through deserialization
@@ -229,11 +234,18 @@ fn ser_smoke_test() {
         c: vec![true, false],
     };
 
-    let expected = Value::Map(vec![
-        (Value::String("a".into()), Value::U32(15)),
-        (Value::String("b".into()), Value::String("hello".into())),
-        (Value::String("c".into()), Value::Seq(vec![Value::Bool(true), Value::Bool(false)])),
-    ].into_iter().collect());
+    let expected = Value::Map(
+        vec![
+            (Value::String("a".into()), Value::U32(15)),
+            (Value::String("b".into()), Value::String("hello".into())),
+            (
+                Value::String("c".into()),
+                Value::Seq(vec![Value::Bool(true), Value::Bool(false)]),
+            ),
+        ]
+        .into_iter()
+        .collect(),
+    );
 
     let value = to_value(&foo).unwrap();
     assert_eq!(expected, value);
@@ -250,9 +262,11 @@ fn deserialize_into_enum() {
     let value = Value::String("Bar".into());
     assert_eq!(Foo::deserialize(value).unwrap(), Foo::Bar);
 
-    let value = Value::Map(vec![
-        (Value::String("Baz".into()), Value::U8(1))
-    ].into_iter().collect());
+    let value = Value::Map(
+        vec![(Value::String("Baz".into()), Value::U8(1))]
+            .into_iter()
+            .collect(),
+    );
     assert_eq!(Foo::deserialize(value).unwrap(), Foo::Baz(1));
 }
 
@@ -265,7 +279,10 @@ fn deserialize_inside_deserialize_impl() {
     }
 
     impl<'de> serde::Deserialize<'de> for Event {
-        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: serde::Deserializer<'de> {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
             #[derive(Deserialize)]
             struct RawEvent {
                 kind: String,
@@ -286,24 +303,45 @@ fn deserialize_inside_deserialize_impl() {
         }
     }
 
-    let input = Value::Map(vec![
-        (Value::String("kind".to_owned()), Value::String("ADDED".to_owned())),
-        (Value::String("object".to_owned()), Value::U32(5)),
-    ].into_iter().collect());
+    let input = Value::Map(
+        vec![
+            (
+                Value::String("kind".to_owned()),
+                Value::String("ADDED".to_owned()),
+            ),
+            (Value::String("object".to_owned()), Value::U32(5)),
+        ]
+        .into_iter()
+        .collect(),
+    );
     let event = Event::deserialize(input).expect("could not deserialize ADDED event");
     assert_eq!(event, Event::Added(5));
 
-    let input = Value::Map(vec![
-        (Value::String("kind".to_owned()), Value::String("ERROR".to_owned())),
-        (Value::String("object".to_owned()), Value::U8(5)),
-    ].into_iter().collect());
+    let input = Value::Map(
+        vec![
+            (
+                Value::String("kind".to_owned()),
+                Value::String("ERROR".to_owned()),
+            ),
+            (Value::String("object".to_owned()), Value::U8(5)),
+        ]
+        .into_iter()
+        .collect(),
+    );
     let event = Event::deserialize(input).expect("could not deserialize ERROR event");
     assert_eq!(event, Event::Error(5));
 
-    let input = Value::Map(vec![
-        (Value::String("kind".to_owned()), Value::String("ADDED".to_owned())),
-        (Value::String("object".to_owned()), Value::Unit),
-    ].into_iter().collect());
+    let input = Value::Map(
+        vec![
+            (
+                Value::String("kind".to_owned()),
+                Value::String("ADDED".to_owned()),
+            ),
+            (Value::String("object".to_owned()), Value::Unit),
+        ]
+        .into_iter()
+        .collect(),
+    );
     let _ = Event::deserialize(input).expect_err("expected deserializing bad ADDED event to fail");
 }
 
@@ -327,9 +365,11 @@ fn deserialize_newtype2() {
         foo: Foo,
     }
 
-    let input = Value::Map(vec![
-        (Value::String("foo".to_owned()), Value::I32(5))
-    ].into_iter().collect());
+    let input = Value::Map(
+        vec![(Value::String("foo".to_owned()), Value::I32(5))]
+            .into_iter()
+            .collect(),
+    );
     let bar = Bar::deserialize(input).unwrap();
     assert_eq!(bar, Bar { foo: Foo(5) });
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,6 +271,60 @@ fn deserialize_into_enum() {
 }
 
 #[test]
+fn serialize_from_enum() {
+    #[derive(Serialize)]
+    enum Foo {
+        Bar,
+        Baz(u8),
+        Qux { quux: u8 },
+        Corge(u8, u8),
+    }
+
+    let bar = Foo::Bar;
+    assert_eq!(to_value(&bar).unwrap(), Value::String("Bar".into()));
+
+    let baz = Foo::Baz(1);
+    assert_eq!(
+        to_value(&baz).unwrap(),
+        Value::Map(
+            vec![(Value::String("Baz".into()), Value::U8(1))]
+                .into_iter()
+                .collect(),
+        )
+    );
+
+    let qux = Foo::Qux { quux: 2 };
+    assert_eq!(
+        to_value(&qux).unwrap(),
+        Value::Map(
+            vec![(
+                Value::String("Qux".into()),
+                Value::Map(
+                    vec![(Value::String("quux".into()), Value::U8(2))]
+                        .into_iter()
+                        .collect()
+                )
+            )]
+            .into_iter()
+            .collect()
+        )
+    );
+
+    let corge = Foo::Corge(3, 4);
+    assert_eq!(
+        to_value(&corge).unwrap(),
+        Value::Map(
+            vec![(
+                Value::String("Corge".into()),
+                Value::Seq(vec![Value::U8(3), Value::U8(4)])
+            )]
+            .into_iter()
+            .collect()
+        )
+    );
+}
+
+#[test]
 fn deserialize_inside_deserialize_impl() {
     #[derive(Debug, PartialEq, Eq)]
     enum Event {

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -134,24 +134,20 @@ impl ser::Serializer for Serializer {
         Ok(Value::Option(None))
     }
 
-    fn serialize_some<T: ?Sized>(
-        self,
-        value: &T
-    ) -> Result<Self::Ok, Self::Error>
+    fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
     where
-        T: ser::Serialize
+        T: ser::Serialize,
     {
-        value.serialize(Serializer).map(|v| Value::Option(Some(Box::new(v))))
+        value
+            .serialize(Serializer)
+            .map(|v| Value::Option(Some(Box::new(v))))
     }
 
     fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
         Ok(Value::Unit)
     }
 
-    fn serialize_unit_struct(
-        self,
-        _name: &'static str
-    ) -> Result<Self::Ok, Self::Error> {
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
         Ok(Value::Unit)
     }
 
@@ -159,7 +155,7 @@ impl ser::Serializer for Serializer {
         self,
         _name: &'static str,
         _variant_index: u32,
-        _variant: &'static str
+        _variant: &'static str,
     ) -> Result<Self::Ok, Self::Error> {
         Ok(Value::Unit)
     }
@@ -167,12 +163,14 @@ impl ser::Serializer for Serializer {
     fn serialize_newtype_struct<T: ?Sized>(
         self,
         _name: &'static str,
-        value: &T
+        value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: ser::Serialize
+        T: ser::Serialize,
     {
-        value.serialize(Serializer).map(|v| Value::Newtype(Box::new(v)))
+        value
+            .serialize(Serializer)
+            .map(|v| Value::Newtype(Box::new(v)))
     }
 
     fn serialize_newtype_variant<T: ?Sized>(
@@ -180,32 +178,28 @@ impl ser::Serializer for Serializer {
         _name: &'static str,
         _variant_index: u32,
         _variant: &'static str,
-        value: &T
+        value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: ser::Serialize
+        T: ser::Serialize,
     {
-        value.serialize(Serializer).map(|v| Value::Newtype(Box::new(v)))
+        value
+            .serialize(Serializer)
+            .map(|v| Value::Newtype(Box::new(v)))
     }
 
-    fn serialize_seq(
-        self,
-        _len: Option<usize>
-    ) -> Result<Self::SerializeSeq, Self::Error> {
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
         Ok(SerializeSeq(vec![]))
     }
 
-    fn serialize_tuple(
-        self,
-        _len: usize
-    ) -> Result<Self::SerializeTuple, Self::Error> {
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
         Ok(SerializeTuple(vec![]))
     }
 
     fn serialize_tuple_struct(
         self,
         _name: &'static str,
-        _len: usize
+        _len: usize,
     ) -> Result<Self::SerializeTupleStruct, Self::Error> {
         Ok(SerializeTupleStruct(vec![]))
     }
@@ -215,22 +209,22 @@ impl ser::Serializer for Serializer {
         _name: &'static str,
         _variant_index: u32,
         _variant: &'static str,
-        _len: usize
+        _len: usize,
     ) -> Result<Self::SerializeTupleVariant, Self::Error> {
         Ok(SerializeTupleVariant(vec![]))
     }
 
-    fn serialize_map(
-        self,
-        _len: Option<usize>
-    ) -> Result<Self::SerializeMap, Self::Error> {
-        Ok(SerializeMap { map: BTreeMap::new(), key: None })
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        Ok(SerializeMap {
+            map: BTreeMap::new(),
+            key: None,
+        })
     }
 
     fn serialize_struct(
         self,
         _name: &'static str,
-        _len: usize
+        _len: usize,
     ) -> Result<Self::SerializeStruct, Self::Error> {
         Ok(SerializeStruct(BTreeMap::new()))
     }
@@ -240,7 +234,7 @@ impl ser::Serializer for Serializer {
         _name: &'static str,
         _variant_index: u32,
         _variant: &'static str,
-        _len: usize
+        _len: usize,
     ) -> Result<Self::SerializeStructVariant, Self::Error> {
         Ok(SerializeStructVariant(BTreeMap::new()))
     }
@@ -252,12 +246,9 @@ impl ser::SerializeSeq for SerializeSeq {
     type Ok = Value;
     type Error = SerializerError;
 
-    fn serialize_element<T: ?Sized>(
-        &mut self,
-        value: &T
-    ) -> Result<(), Self::Error>
+    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: ser::Serialize
+        T: ser::Serialize,
     {
         let value = value.serialize(Serializer)?;
         self.0.push(value);
@@ -275,12 +266,9 @@ impl ser::SerializeTuple for SerializeTuple {
     type Ok = Value;
     type Error = SerializerError;
 
-    fn serialize_element<T: ?Sized>(
-        &mut self,
-        value: &T
-    ) -> Result<(), Self::Error>
+    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: ser::Serialize
+        T: ser::Serialize,
     {
         let value = value.serialize(Serializer)?;
         self.0.push(value);
@@ -298,12 +286,9 @@ impl ser::SerializeTupleStruct for SerializeTupleStruct {
     type Ok = Value;
     type Error = SerializerError;
 
-    fn serialize_field<T: ?Sized>(
-        &mut self,
-        value: &T
-    ) -> Result<(), Self::Error>
+    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: ser::Serialize
+        T: ser::Serialize,
     {
         let value = value.serialize(Serializer)?;
         self.0.push(value);
@@ -321,12 +306,9 @@ impl ser::SerializeTupleVariant for SerializeTupleVariant {
     type Ok = Value;
     type Error = SerializerError;
 
-    fn serialize_field<T: ?Sized>(
-        &mut self,
-        value: &T
-    ) -> Result<(), Self::Error>
+    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: ser::Serialize
+        T: ser::Serialize,
     {
         let value = value.serialize(Serializer)?;
         self.0.push(value);
@@ -349,19 +331,16 @@ impl ser::SerializeMap for SerializeMap {
 
     fn serialize_key<T: ?Sized>(&mut self, key: &T) -> Result<(), Self::Error>
     where
-        T: ser::Serialize
+        T: ser::Serialize,
     {
         let key = key.serialize(Serializer)?;
         self.key = Some(key);
         Ok(())
     }
 
-    fn serialize_value<T: ?Sized>(
-        &mut self,
-        value: &T
-    ) -> Result<(), Self::Error>
+    fn serialize_value<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: ser::Serialize
+        T: ser::Serialize,
     {
         let value = value.serialize(Serializer)?;
         self.map.insert(self.key.take().unwrap(), value);
@@ -382,10 +361,10 @@ impl ser::SerializeStruct for SerializeStruct {
     fn serialize_field<T: ?Sized>(
         &mut self,
         key: &'static str,
-        value: &T
+        value: &T,
     ) -> Result<(), Self::Error>
     where
-        T: ser::Serialize
+        T: ser::Serialize,
     {
         let key = Value::String(key.to_string());
         let value = value.serialize(Serializer)?;
@@ -407,10 +386,10 @@ impl ser::SerializeStructVariant for SerializeStructVariant {
     fn serialize_field<T: ?Sized>(
         &mut self,
         key: &'static str,
-        value: &T
+        value: &T,
     ) -> Result<(), Self::Error>
     where
-        T: ser::Serialize
+        T: ser::Serialize,
     {
         let key = Value::String(key.to_string());
         let value = value.serialize(Serializer)?;


### PR DESCRIPTION
Fix #18 

This PR will allow the following tests to pass.

```rust
#[derive(serde::Serialize)]
enum Foo {
    Bar,
}

let foo = Foo::Bar;
assert_eq!(
    serde_json::to_string(&foo).unwrap(),
    serde_json::to_string(&serde_value::to_value(&foo).unwrap()).unwrap()
);
```

This PR has breaking changes.