### PR TITLE
Upgrade to ordered-float v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "serde-value"
 version = "0.6.0"
 authors = ["arcnmx"]
+edition = "2018"
 
 description = "Serialization value trees"
 documentation = "http://arcnmx.github.io/serde-value/serde_value/"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,5 @@
 #![doc(html_root_url="https://arcnmx.github.io/serde-value")]
 
-#[macro_use]
-extern crate serde;
-extern crate ordered_float;
-
-#[cfg(test)]
-#[macro_use]
-extern crate serde_derive;
-
 use std::collections::BTreeMap;
 use std::cmp::Ordering;
 use std::hash::{Hash, Hasher};
@@ -192,6 +184,9 @@ impl PartialOrd for Value {
         Some(self.cmp(rhs))
     }
 }
+
+#[cfg(test)]
+use serde_derive::{Deserialize, Serialize};
 
 #[test]
 fn de_smoke_test() {

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use std::error::Error;
 use std::fmt;
 
-use Value;
+use crate::Value;
 
 #[derive(Debug)]
 pub enum SerializerError {


### PR DESCRIPTION
Two commits in here.

**Upgrade to ordered-float v2**. 
The new version is semver incompatible with v1; upgrading here reduces the chance of duplicate copies of ordered-float in large dependency graphs.

----

**Upgrade to Rust 2018**. 
Since ordered-float v2 bumps the MSRV to 1.34, might as well take the
opportunity to upgrade to Rust 2018 syntax.
